### PR TITLE
Do not join already joined IRC channels

### DIFF
--- a/src/main/java/fr/raksrinana/channelpointsminer/irc/TwitchIrcClient.java
+++ b/src/main/java/fr/raksrinana/channelpointsminer/irc/TwitchIrcClient.java
@@ -23,6 +23,10 @@ public class TwitchIrcClient implements AutoCloseable{
 	public void join(@NotNull String channel){
 		var client = getIrcClient();
 		var ircChannelName = "#%s".formatted(channel.toLowerCase(Locale.ROOT));
+		if(client.getChannel(ircChannelName).isPresent()){
+			log.trace("Tried to join IRC channel {} that is already joined", ircChannelName);
+			return;
+		}
 		
 		log.info("Joining IRC channel {}", ircChannelName);
 		client.addChannel(ircChannelName);
@@ -35,6 +39,10 @@ public class TwitchIrcClient implements AutoCloseable{
 		}
 		
 		var ircChannelName = "#%s".formatted(channel);
+		if(ircClient.getChannel(ircChannelName).isEmpty()){
+			log.trace("Tried to leave IRC channel {} that is not joined", ircChannelName);
+			return;
+		}
 		
 		log.info("Leaving IRC channel {}", ircChannelName);
 		ircClient.removeChannel(ircChannelName);


### PR DESCRIPTION
## Pull Request Etiquette

### Checklist

- [x] Tests have been added in relevant areas
- [ ] Corresponding changes made to the documentation (README.adoc)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Description

If an IRC channel is already joined, do not join it back. Same when leaving a channel.
